### PR TITLE
Don't use NO_SERVICE for bulletins affecting all traffic

### DIFF
--- a/src/main/java/fi/hsl/transitdata/alert/AlertHandler.java
+++ b/src/main/java/fi/hsl/transitdata/alert/AlertHandler.java
@@ -227,10 +227,19 @@ public class AlertHandler implements IMessageHandler {
         final boolean affectsAll = bulletinAffectsAll(bulletin);
         final InternalMessages.Bulletin.Impact impact = bulletin.getImpact();
 
+        final GtfsRealtime.Alert.Effect effect = toGtfsEffect(impact);
+        if (effect == GtfsRealtime.Alert.Effect.NO_SERVICE && affectsAll) {
+            //If the bulletin affects all traffic (i.e. entity selector list contains agency), we don't want to use NO_SERVICE effect, because otherwise Google and others will display all traffic as cancelled
+            return GtfsRealtime.Alert.Effect.REDUCED_SERVICE;
+        }
+
+        return effect;
+    }
+
+    public static GtfsRealtime.Alert.Effect toGtfsEffect(final InternalMessages.Bulletin.Impact impact) {
         switch (impact) {
             case CANCELLED:
-                //If the bulletin affects all traffic (i.e. entity selector list contains agency), we don't want to use NO_SERVICE effect, because otherwise Google and others will display all traffic as cancelled
-                return affectsAll ? GtfsRealtime.Alert.Effect.REDUCED_SERVICE : GtfsRealtime.Alert.Effect.NO_SERVICE;
+                return GtfsRealtime.Alert.Effect.NO_SERVICE;
             case DELAYED:
             case IRREGULAR_DEPARTURES:
                 return GtfsRealtime.Alert.Effect.SIGNIFICANT_DELAYS;

--- a/src/main/java/fi/hsl/transitdata/alert/AlertHandler.java
+++ b/src/main/java/fi/hsl/transitdata/alert/AlertHandler.java
@@ -25,7 +25,7 @@ public class AlertHandler implements IMessageHandler {
 
     public AlertHandler(final PulsarApplicationContext context) {
         consumer = context.getConsumer();
-        producer = context.getProducer();
+        producer = context.getSingleProducer();
     }
 
     public void handleMessage(final Message message) {
@@ -72,6 +72,10 @@ public class AlertHandler implements IMessageHandler {
                 .collect(Collectors.toList());
     }
 
+    private static boolean bulletinAffectsAll(InternalMessages.Bulletin bulletin) {
+        return bulletin.getAffectsAllRoutes() || bulletin.getAffectsAllStops();
+    }
+
     static Optional<GtfsRealtime.Alert> createAlert(final InternalMessages.Bulletin bulletin) {
         Optional<GtfsRealtime.Alert> maybeAlert;
         try {
@@ -90,7 +94,7 @@ public class AlertHandler implements IMessageHandler {
             final GtfsRealtime.Alert.Builder builder = GtfsRealtime.Alert.newBuilder();
             builder.addActivePeriod(timeRange);
             builder.setCause(toGtfsCause(bulletin.getCategory()));
-            builder.setEffect(toGtfsEffect(bulletin.getImpact()));
+            builder.setEffect(getGtfsEffect(bulletin));
             if (bulletin.getTitlesCount() > 0) {
                 builder.setHeaderText(toGtfsTranslatedString(bulletin.getTitlesList()));
             }
@@ -127,7 +131,7 @@ public class AlertHandler implements IMessageHandler {
 
     static Collection<GtfsRealtime.EntitySelector> entitySelectorsForBulletin(final InternalMessages.Bulletin bulletin) {
         Set<GtfsRealtime.EntitySelector> selectors = new HashSet<>();
-        if (bulletin.getAffectsAllRoutes() || bulletin.getAffectsAllStops()) {
+        if (bulletinAffectsAll(bulletin)) {
             log.debug("Bulletin {} affects all routes or stops", bulletin.getBulletinId());
 
             GtfsRealtime.EntitySelector agency = GtfsRealtime.EntitySelector.newBuilder()
@@ -219,10 +223,14 @@ public class AlertHandler implements IMessageHandler {
         }
     }
 
-    public static GtfsRealtime.Alert.Effect toGtfsEffect(final InternalMessages.Bulletin.Impact impact) {
+    public static GtfsRealtime.Alert.Effect getGtfsEffect(final InternalMessages.Bulletin bulletin) {
+        final boolean affectsAll = bulletinAffectsAll(bulletin);
+        final InternalMessages.Bulletin.Impact impact = bulletin.getImpact();
+
         switch (impact) {
             case CANCELLED:
-                return GtfsRealtime.Alert.Effect.NO_SERVICE;
+                //If the bulletin affects all traffic (i.e. entity selector list contains agency), we don't want to use NO_SERVICE effect, because otherwise Google and others will display all traffic as cancelled
+                return affectsAll ? GtfsRealtime.Alert.Effect.REDUCED_SERVICE : GtfsRealtime.Alert.Effect.NO_SERVICE;
             case DELAYED:
             case IRREGULAR_DEPARTURES:
                 return GtfsRealtime.Alert.Effect.SIGNIFICANT_DELAYS;

--- a/src/test/java/fi/hsl/transitdata/alert/AlertHandlerTest.java
+++ b/src/test/java/fi/hsl/transitdata/alert/AlertHandlerTest.java
@@ -23,22 +23,9 @@ import static org.junit.Assert.*;
 public class AlertHandlerTest {
 
     private byte[] readProtobufFromResourceFile(final String filename) throws IOException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        URL url =  classLoader.getResource(filename);
-        byte[] data;
-        try  (InputStream inputStream = url.openStream()) {
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-            byte[] readWindow = new byte[256];
-            int numberOfBytesRead;
-
-            while ((numberOfBytesRead = inputStream.read(readWindow)) > 0) {
-                byteArrayOutputStream.write(readWindow, 0, numberOfBytesRead);
-            }
-
-            data = byteArrayOutputStream.toByteArray();
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(filename)) {
+            return is.readAllBytes();
         }
-        return data;
     }
 
     private InternalMessages.ServiceAlert readDefaultMockData() throws IOException {

--- a/src/test/java/fi/hsl/transitdata/alert/AlertHandlerTest.java
+++ b/src/test/java/fi/hsl/transitdata/alert/AlertHandlerTest.java
@@ -225,4 +225,24 @@ public class AlertHandlerTest {
         assertTrue(selectors.contains(GtfsRealtime.EntitySelector.newBuilder().setRouteId("1009").build()));
         assertFalse(selectors.contains(GtfsRealtime.EntitySelector.newBuilder().setRouteId("1009 1").build()));
     }
+
+    @Test
+    public void testNoServiceEffectIsNotUsedWhenBulletinAffectAll() {
+        InternalMessages.Bulletin bulletin = InternalMessages.Bulletin.newBuilder()
+                .setBulletinId("1")
+                .setAffectsAllRoutes(true)
+                .setAffectsAllStops(true)
+                .setCategory(InternalMessages.Category.STRIKE)
+                .setImpact(InternalMessages.Bulletin.Impact.CANCELLED)
+                .setValidFromUtcMs(0)
+                .setValidToUtcMs(Long.MAX_VALUE)
+                .setLastModifiedUtcMs(Instant.now().getEpochSecond())
+                .addDescriptions(InternalMessages.Bulletin.Translation.newBuilder().setLanguage("en").setText("Test"))
+                .setDisplayOnly(false)
+                .build();
+
+        Optional<GtfsRealtime.Alert> alert = AlertHandler.createAlert(bulletin);
+        assertTrue(alert.isPresent());
+        assertNotEquals(GtfsRealtime.Alert.Effect.NO_SERVICE, alert.get().getEffect());
+    }
 }


### PR DESCRIPTION
Using NO_SERVICE causes Google and other third-party services to consider all departures as cancelled